### PR TITLE
add manifest for worker, terraform for bucket and secret IAM access

### DIFF
--- a/k8s/worker.yaml
+++ b/k8s/worker.yaml
@@ -1,24 +1,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: podscriber-web
+  name: podscriber-worker
   namespace: podscriber
   labels:
-    app: podscriber-web
+    app: podscriber-worker
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: podscriber-web
+      app: podscriber-worker
   template:
     metadata:
       labels:
-        app: podscriber-web
+        app: podscriber-worker
     spec:
       serviceAccount: podscriber
       containers:
-      - name: web
-        image: us.gcr.io/oddmark-stage/podscriber-web:latest
+      - name: worker
+        image: us.gcr.io/oddmark-stage/podscriber-worker:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8000
@@ -27,8 +27,10 @@ spec:
           value: "true"
         envFrom:
         - configMapRef:
-            name: podscriber-web
+            name: podscriber-worker
         - secretRef:
-            name: podscriber-web
+            name: podscriber-worker
+        command: ["rq"]
+        args: ["worker", "-c", "settings", "--with-scheduler"]
         #command: ["tail"]
         #args: ["-f", "/dev/null"]

--- a/terraform/modules/service-modules/podscriber/bucket_iam.tf
+++ b/terraform/modules/service-modules/podscriber/bucket_iam.tf
@@ -1,0 +1,12 @@
+resource "google_project_iam_custom_role" "static_asset_reader" {
+  role_id     = "staticAssetReader"
+  title       = "staticAssetReader"
+  permissions = ["storage.objects.get"]
+}
+
+
+resource "google_storage_bucket_iam_member" "static_asset_reader" {
+  bucket = google_storage_bucket.static.name
+  role   = google_project_iam_custom_role.static_asset_reader.id
+  member = "serviceAccount:${var.gcp_sa_email}"
+}

--- a/terraform/modules/service-modules/podscriber/buckets.tf
+++ b/terraform/modules/service-modules/podscriber/buckets.tf
@@ -3,13 +3,21 @@ resource "google_storage_bucket" "transcripts" {
   location      = var.region
   force_destroy = true
 }
+
 resource "google_storage_bucket" "podcasts" {
   name          = "oddmark-podcasts-${var.environment}"
   location      = var.region
   force_destroy = true
 }
+
 resource "google_storage_bucket" "excerpts" {
   name          = "oddmark-excerpts-${var.environment}"
+  location      = var.region
+  force_destroy = true
+}
+
+resource "google_storage_bucket" "static" {
+  name          = "oddmark-static-assets-${var.environment}"
   location      = var.region
   force_destroy = true
 }

--- a/terraform/modules/service-modules/podscriber/config-secret.tf
+++ b/terraform/modules/service-modules/podscriber/config-secret.tf
@@ -59,6 +59,7 @@ resource "kubernetes_config_map" "podscriber_worker" {
     WORKER_PODCAST_MEDIA_GCS_BUCKET    = google_storage_bucket.podcasts.name
     WORKER_EXCERPT_MEDIA_GCS_BUCKET    = google_storage_bucket.excerpts.name
     WORKER_TRANSCRIPT_MEDIA_GCS_BUCKET = google_storage_bucket.transcripts.name
+    WORKER_SECRET_MANAGER_SECRET_NAME  = "podscriber-worker"
   }
 }
 

--- a/terraform/modules/service-modules/podscriber/db.tf
+++ b/terraform/modules/service-modules/podscriber/db.tf
@@ -23,7 +23,7 @@ resource "google_sql_database_instance" "instance" {
   settings {
     tier = var.db_instance_tier
     ip_configuration {
-      ipv4_enabled = false
+      ipv4_enabled    = false
       private_network = var.network_id
     }
   }

--- a/terraform/modules/service-modules/podscriber/secret_iam.tf
+++ b/terraform/modules/service-modules/podscriber/secret_iam.tf
@@ -1,0 +1,13 @@
+resource "google_project_iam_custom_role" "secret_reader" {
+  role_id     = "secretReader"
+  title       = "secretReader"
+  permissions = ["secretmanager.versions.access"]
+}
+
+resource "google_secret_manager_secret_iam_member" "member" {
+  #TODO: look this up with a data resource whenever they add one
+  # https://www.terraform.io/docs/providers/google/d/datasource_google_secret_manager_secret_version.html
+  secret_id = "projects/oddmark-stage/secrets/podscriber-worker"
+  role   = google_project_iam_custom_role.secret_reader.id
+  member = "serviceAccount:${var.gcp_sa_email}"
+}

--- a/terraform/modules/service-modules/podscriber/variables.tf
+++ b/terraform/modules/service-modules/podscriber/variables.tf
@@ -18,6 +18,10 @@ variable "k8s_namespace" {
   type = string
 }
 
+variable "gcp_sa_email" {
+  type = string
+}
+
 variable "network_id" {
   type = string
 }

--- a/terraform/modules/service-modules/workload/outputs.tf
+++ b/terraform/modules/service-modules/workload/outputs.tf
@@ -1,3 +1,7 @@
 output "k8s_namespace" {
   value = kubernetes_namespace.namespace.metadata.0.name
 }
+
+output "gcp_sa_email" {
+  value = google_service_account.sa.email
+}

--- a/terraform/platforms/global/variables.tf
+++ b/terraform/platforms/global/variables.tf
@@ -10,5 +10,6 @@ variable "required_apis" {
     "logging.googleapis.com",
     "redis.googleapis.com",
     "servicenetworking.googleapis.com",
+    "secretmanager.googleapis.com",
   ]
 }

--- a/terraform/services/podscriber/main.tf
+++ b/terraform/services/podscriber/main.tf
@@ -10,5 +10,6 @@ module "podscriber" {
   location         = var.location
   db_instance_tier = var.db_instance_tier
   k8s_namespace    = module.workload.k8s_namespace
+  gcp_sa_email     = module.workload.gcp_sa_email
   network_id       = data.google_compute_network.main.id
 }


### PR DESCRIPTION
Groundwork for utilizing workload identity. Grant access GCS buckets and Secret Manager secrets. Also add a manifest for the batch workers.