### PR TITLE
Istio accesslogs

### DIFF
--- a/k8s/istio/install.yaml
+++ b/k8s/istio/install.yaml
@@ -5227,8 +5227,6 @@ metadata:
   name: istiooperators.install.istio.io
   labels:
     release: istio
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.revision
@@ -6690,6 +6688,93 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  name: stackdriver-filter-1.4
+  namespace: istio-system
+  labels:
+    istio.io/rev: default
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.4.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          config:
+            config:
+              root_id: stackdriver_outbound
+              configuration: |
+                {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s"}
+              vm_config:
+                vm_id: stackdriver_outbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  inline_string: envoy.wasm.null.stackdriver
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        proxy:
+          proxyVersion: '^1\.4.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          config:
+            config:
+              root_id: stackdriver_inbound
+              configuration: |
+                {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s"}
+              vm_config:
+                vm_id: stackdriver_inbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  inline_string: envoy.wasm.null.stackdriver
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.4.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          config:
+            config:
+              root_id: stackdriver_outbound
+              configuration: |
+                {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s", "disable_host_header_fallback": true}
+              vm_config:
+                vm_id: stackdriver_outbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  inline_string: envoy.wasm.null.stackdriver
+---
+
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
   name: metadata-exchange-1.5
   namespace: istio-system
   labels:
@@ -6987,6 +7072,102 @@ spec:
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
+---
+
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: stackdriver-filter-1.5
+  namespace: istio-system
+  labels:
+    istio.io/rev: default
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.5.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.config.filter.http.wasm.v2.Wasm
+            value:
+              config:
+                root_id: stackdriver_outbound
+                configuration: |
+                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s"}
+                vm_config:
+                  vm_id: stackdriver_outbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local: { inline_string: envoy.wasm.null.stackdriver }
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        proxy:
+          proxyVersion: '^1\.5.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.config.filter.http.wasm.v2.Wasm
+            value:
+              config:
+                root_id: stackdriver_inbound
+                configuration: |
+                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s"}
+                vm_config:
+                  vm_id: stackdriver_inbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local: { inline_string: envoy.wasm.null.stackdriver }
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.5.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.config.filter.http.wasm.v2.Wasm
+            value:
+              config:
+                root_id: stackdriver_outbound
+                configuration: |
+                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s", "disable_host_header_fallback": true}
+                vm_config:
+                  vm_id: stackdriver_outbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local: { inline_string: envoy.wasm.null.stackdriver }
 ---
 
 
@@ -7294,6 +7475,102 @@ spec:
                   code:
                     local:
                       inline_string: "envoy.wasm.stats"
+---
+
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: stackdriver-filter-1.6
+  namespace: istio-system
+  labels:
+    istio.io/rev: default
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stackdriver
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stackdriver_outbound
+                configuration: |
+                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s"}
+                vm_config:
+                  vm_id: stackdriver_outbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local: { inline_string: envoy.wasm.null.stackdriver }
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stackdriver
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stackdriver_inbound
+                configuration: |
+                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s"}
+                vm_config:
+                  vm_id: stackdriver_inbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local: { inline_string: envoy.wasm.null.stackdriver }
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.6.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stackdriver
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stackdriver_outbound
+                configuration: |
+                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s", "disable_host_header_fallback": true}
+                vm_config:
+                  vm_id: stackdriver_outbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local: { inline_string: envoy.wasm.null.stackdriver }
 ---
 
 # Policy component is disabled.

--- a/k8s/istio/install.yaml
+++ b/k8s/istio/install.yaml
@@ -5675,7 +5675,7 @@ data:
 
   mesh: |-
     accessLogEncoding: TEXT
-    accessLogFile: /dev/stdout
+    accessLogFile: ""
     accessLogFormat: ""
     defaultConfig:
       concurrency: 2

--- a/k8s/istio/install.yaml
+++ b/k8s/istio/install.yaml
@@ -5227,6 +5227,8 @@ metadata:
   name: istiooperators.install.istio.io
   labels:
     release: istio
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.revision
@@ -6713,7 +6715,7 @@ spec:
             config:
               root_id: stackdriver_outbound
               configuration: |
-                {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s"}
+                {"enable_mesh_edges_reporting": false, "disable_server_access_logging": false, "meshEdgesReportingDuration": "600s"}
               vm_config:
                 vm_id: stackdriver_outbound
                 runtime: envoy.wasm.runtime.null
@@ -6738,7 +6740,7 @@ spec:
             config:
               root_id: stackdriver_inbound
               configuration: |
-                {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s"}
+                {"enable_mesh_edges_reporting": false, "disable_server_access_logging": false, "meshEdgesReportingDuration": "600s"}
               vm_config:
                 vm_id: stackdriver_inbound
                 runtime: envoy.wasm.runtime.null
@@ -6763,7 +6765,7 @@ spec:
             config:
               root_id: stackdriver_outbound
               configuration: |
-                {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s", "disable_host_header_fallback": true}
+                {"enable_mesh_edges_reporting": false, "disable_server_access_logging": false, "meshEdgesReportingDuration": "600s", "disable_host_header_fallback": true}
               vm_config:
                 vm_id: stackdriver_outbound
                 runtime: envoy.wasm.runtime.null
@@ -7106,7 +7108,7 @@ spec:
               config:
                 root_id: stackdriver_outbound
                 configuration: |
-                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s"}
+                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": false, "meshEdgesReportingDuration": "600s"}
                 vm_config:
                   vm_id: stackdriver_outbound
                   runtime: envoy.wasm.runtime.null
@@ -7134,7 +7136,7 @@ spec:
               config:
                 root_id: stackdriver_inbound
                 configuration: |
-                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s"}
+                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": false, "meshEdgesReportingDuration": "600s"}
                 vm_config:
                   vm_id: stackdriver_inbound
                   runtime: envoy.wasm.runtime.null
@@ -7162,7 +7164,7 @@ spec:
               config:
                 root_id: stackdriver_outbound
                 configuration: |
-                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s", "disable_host_header_fallback": true}
+                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": false, "meshEdgesReportingDuration": "600s", "disable_host_header_fallback": true}
                 vm_config:
                   vm_id: stackdriver_outbound
                   runtime: envoy.wasm.runtime.null
@@ -7509,7 +7511,7 @@ spec:
               config:
                 root_id: stackdriver_outbound
                 configuration: |
-                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s"}
+                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": false, "meshEdgesReportingDuration": "600s"}
                 vm_config:
                   vm_id: stackdriver_outbound
                   runtime: envoy.wasm.runtime.null
@@ -7537,7 +7539,7 @@ spec:
               config:
                 root_id: stackdriver_inbound
                 configuration: |
-                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s"}
+                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": false, "meshEdgesReportingDuration": "600s"}
                 vm_config:
                   vm_id: stackdriver_inbound
                   runtime: envoy.wasm.runtime.null
@@ -7565,7 +7567,7 @@ spec:
               config:
                 root_id: stackdriver_outbound
                 configuration: |
-                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": true, "meshEdgesReportingDuration": "600s", "disable_host_header_fallback": true}
+                  {"enable_mesh_edges_reporting": false, "disable_server_access_logging": false, "meshEdgesReportingDuration": "600s", "disable_host_header_fallback": true}
                 vm_config:
                   vm_id: stackdriver_outbound
                   runtime: envoy.wasm.runtime.null

--- a/terraform/modules/platform-modules/gke-cluster/iam.tf
+++ b/terraform/modules/platform-modules/gke-cluster/iam.tf
@@ -16,3 +16,8 @@ resource "google_project_iam_member" "monitoring_viewer" {
   role   = "roles/monitoring.viewer"
   member = "serviceAccount:${google_service_account.cluster_service_account.email}"
 }
+
+resource "google_project_iam_member" "metadata_writer" {
+  role   = "roles/stackdriver.resourceMetadata.writer"
+  member = "serviceAccount:${google_service_account.cluster_service_account.email}"
+}

--- a/terraform/modules/service-modules/podscriber/gcp_iam.tf
+++ b/terraform/modules/service-modules/podscriber/gcp_iam.tf
@@ -26,3 +26,15 @@ resource "google_secret_manager_secret_iam_member" "member" {
   role      = google_project_iam_custom_role.secret_reader.id
   member    = "serviceAccount:${var.gcp_sa_email}"
 }
+
+# grant access to write stackdriver logs (used by istio sidecar)
+resource "google_project_iam_member" "log_writer" {
+  role   = "roles/logging.logWriter"
+  member = "serviceAccount:${var.gcp_sa_email}"
+}
+
+# grant access to write stackdriver metrics (used by istio sidecar)
+resource "google_project_iam_member" "metric_writer" {
+  role   = "roles/monitoring.metricWriter"
+  member = "serviceAccount:${var.gcp_sa_email}"
+}

--- a/terraform/modules/service-modules/workload/iam.tf
+++ b/terraform/modules/service-modules/workload/iam.tf
@@ -8,6 +8,9 @@ resource "google_service_account" "sa" {
 resource "kubernetes_namespace" "namespace" {
   metadata {
     name = var.name
+    labels = {
+      istio-injection = "enabled"
+    }
   }
 }
 


### PR DESCRIPTION
Toss out envoy access logs, replace with WASM based stackdriver istio telemetry v2 logs.